### PR TITLE
Update plantuml doctor prescription

### DIFF
--- a/modules/lang/plantuml/doctor.el
+++ b/modules/lang/plantuml/doctor.el
@@ -7,4 +7,4 @@
     (warn! "Couldn't find java. PlantUML preview or syntax checking won't work"))
   ;; plantuml.jar
   (unless (file-exists-p plantuml-jar-path)
-    (warn! "Couldn't find plantuml.jar. Install it with-x +plantuml/install")))
+    (warn! "Couldn't find plantuml.jar. Install it with M-x plantuml-download-jar")))


### PR DESCRIPTION
This patch changes the recommendation from +plantuml/install to
plantuml-dowload-jar, when the plantuml.jar can't be found. The command
+plantuml/install has been removed in a previous patch.


----

#